### PR TITLE
ensure that java file output is complete before completing task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group 'com.fsryan.gradle.smc'
-version '0.0.2'
+version '0.1.0'
 
 repositories {
     mavenCentral()
@@ -32,9 +32,9 @@ bintray {
         licenses = ['Mozilla-1.1']
         vcsUrl = 'https://github.com/ryansgot/smc-gradle-plugin'
         version {
-            name = '0.0.2'
+            name = '0.1.0'
             released  = new Date()
-            vcsTag = 'v0.0.2'
+            vcsTag = 'v0.1.0'
         }
     }
 }
@@ -56,26 +56,6 @@ def pomConfig = {
     }
 }
 
-publishing {
-    publications {
-        smcPluginPublication(MavenPublication) {
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
-            groupId 'com.fsryan.gradle.smc'
-            artifactId 'smc'
-            version '0.0.2'
-            pom.withXml {
-                def root = asNode()
-                root.appendNode('description', 'Gradle plugin for the State Machine Compiler (SMC) that makes it easier to use in a gradle project')
-                root.appendNode('name', 'smc-gradle-plugin')
-                root.appendNode('url', 'https://github.com/ryansgot/smc-gradle-plugin')
-                root.children().last() + pomConfig
-            }
-        }
-    }
-}
-
 task release(dependsOn: bintrayUpload) {
     doLast {
         println("Huzzah! smc-gradle-plugin was uploaded to bintray!")
@@ -90,4 +70,24 @@ task sourcesJar(type: Jar) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
+}
+
+publishing {
+    publications {
+        smcPluginPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId 'com.fsryan.gradle.smc'
+            artifactId 'smc'
+            version '0.1.0'
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Gradle plugin for the State Machine Compiler (SMC) that makes it easier to use in a gradle project')
+                root.appendNode('name', 'smc-gradle-plugin')
+                root.appendNode('url', 'https://github.com/ryansgot/smc-gradle-plugin')
+                root.children().last() + pomConfig
+            }
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip

--- a/src/main/groovy/com/fsryan/gradle/smc/SmCompiler.groovy
+++ b/src/main/groovy/com/fsryan/gradle/smc/SmCompiler.groovy
@@ -1,5 +1,7 @@
 package com.fsryan.gradle.smc
 
+import java.util.concurrent.TimeUnit
+
 class SmCompiler {
 
     private File srcDir
@@ -42,7 +44,10 @@ class SmCompiler {
     }
 
     private void createOutputs(SmcCommander commander) {
-        commander.generateStateMachine().execute()
+        def successful = commander.generateStateMachine().execute().waitFor(15000, TimeUnit.MILLISECONDS)
+        if (!successful) {
+            throw new IllegalStateException("Failed to create state machine Java file after 15 seconds in output directory: ${commander.artifactOutputDir}")
+        }
         if (generateDotFile()) {
             commander.generateDotFile(graphVizLevel).execute()
         }

--- a/src/main/groovy/com/fsryan/gradle/smc/SmcCommander.groovy
+++ b/src/main/groovy/com/fsryan/gradle/smc/SmcCommander.groovy
@@ -4,8 +4,8 @@ class SmcCommander {
 
     private String smcJarFile
     private String inputFile
-    private File javaOutputDir
-    private File artifactOutputDir
+    File javaOutputDir
+    File artifactOutputDir
 
     SmcCommander(String smcJarFile, String inputFile, File javaOutputDir, File artifactOutputDir) {
         this.smcJarFile = smcJarFile


### PR DESCRIPTION
The issue was caused by the fact that although the process of running `Smc.jar` was spawned, the process was not waited on, and subsequent tasks were allowed to run concurrently.